### PR TITLE
vercelでのデプロイ時にbuildに失敗したのを修正

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -9,7 +9,7 @@ const POST_NAME = "page.mdx";
 const POST_PATH = path.join("**", POST_NAME);
 const POST_URL_PREFIX = "/posts/";
 
-export const getAllPosts = async () => {
+const getAllPosts = async () => {
   return Promise.all(
     globSync(POST_PATH, { cwd: POSTS_DIR }).map(async (postPath) => {
       const fullPath = path.join(POSTS_DIR, postPath);


### PR DESCRIPTION
page.tsxで間違って余計な関数をexportしたら `"getAllPosts" is not a valid Page export field.` と言われた。
モジュールがNext.jsのページに必要な要素を過不足なくexportしているかどうかはちゃんとチェックされているんだなぁ

<img width="588" alt="image" src="https://github.com/MasaoBlue/tech-life-blog/assets/16271994/7fa2a50e-19b2-4461-846c-5204f9d75cfb">
